### PR TITLE
Sign in

### DIFF
--- a/packages/frontend/src/components/infoCard.jsx
+++ b/packages/frontend/src/components/infoCard.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Button, Grid, Segment, Message, Container } from "semantic-ui-react";
+import { Button, Grid, Segment, Message } from "semantic-ui-react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faTwitter, faGithub } from "@fortawesome/free-brands-svg-icons";
 
@@ -7,6 +7,7 @@ const InfoCard = ({
   title,
   platform,
   hasSignedUp,
+  connected,
   data,
   provableData,
   color,
@@ -60,8 +61,8 @@ const InfoCard = ({
           </Grid.Column>
           <Grid.Column width={4}>
             <h3>{title}</h3>
-            <p className={hasSignedUp ? "connected" : "unconnected"}>
-              {hasSignedUp ? "connected" : "unconnected"}
+            <p className={connected ? "connected" : "unconnected"}>
+              {connected ? "connected" : "unconnected"}
             </p>
           </Grid.Column>
           <Grid.Column width={7} verticalAlign="middle">
@@ -76,24 +77,34 @@ const InfoCard = ({
               <p>Not connected</p>
             )}
           </Grid.Column>
-          <Grid.Column width={2}>
-            {hasSignedUp && (
-              <Button onClick={onClickUpdate} loading={isUpdating}>
-                Update
-              </Button>
-            )}
-          </Grid.Column>
-          <Grid.Column width={2}>
-            {hasSignedUp ? (
-              <Button onClick={onClickUST} loading={isUSTing}>
-                UST
-              </Button>
-            ) : (
+          {!hasSignedUp && (
+            <Grid.Column width={4}>
               <Button onClick={connect} loading={connectLoading}>
                 Connect!
               </Button>
-            )}
-          </Grid.Column>
+            </Grid.Column>
+          )}
+          {hasSignedUp && !connected && (
+            <Grid.Column width={2}>
+              <Button onClick={connect} loading={connectLoading}>
+                Connect!
+              </Button>
+            </Grid.Column>
+          )}
+          {hasSignedUp && connected && (
+            <Grid.Column width={2}>
+              <Button onClick={onClickUpdate} loading={isUpdating}>
+                Update
+              </Button>
+            </Grid.Column>
+          )}
+          {hasSignedUp && (
+            <Grid.Column width={2}>
+              <Button onClick={onClickUST} loading={isUSTing}>
+                UST
+              </Button>
+            </Grid.Column>
+          )}
         </Grid.Row>
         {errorMsg.length > 0 && (
           <Grid.Row>

--- a/packages/frontend/src/contexts/User.js
+++ b/packages/frontend/src/contexts/User.js
@@ -95,6 +95,15 @@ class User {
     if (!this.userStates[platform]) throw new Error("userState is undefined");
   }
 
+  async login(id) {
+    if (!id || id.length === 0) {
+      throw new Error("You have not entered identity yet.");
+    }
+    const identity = new ZkIdentity(Strategy.SERIALIZED, id);
+    localStorage.setItem("id", identity.serializeIdentity());
+    await this.load();
+  }
+
   updateHasSignedUp() {
     for (const [platform, us] of Object.entries(this.userStates)) {
       this.hasSignedUp = this.hasSignedUp || us.hasSignedUp;

--- a/packages/frontend/src/contexts/User.js
+++ b/packages/frontend/src/contexts/User.js
@@ -66,12 +66,15 @@ class User {
       const data = await userState.getData();
       const provableData = await userState.getProvableData();
 
+      const access_token = localStorage.getItem(`${platform}_access_token`);
+
       this.userStates[platform] = {
         userState,
         hasSignedUp,
         latestTransitionedEpoch,
         data,
         provableData,
+        access_token,
       };
     }
     this.updateHasSignedUp();
@@ -129,9 +132,6 @@ class User {
     /* Wait for loading userStates */
     await this.waitForLoad(platform);
 
-    /* Store access_token to local storage */
-    localStorage.setItem(`${platform}_access_token`, access_token);
-
     /* Gen signupProof */
     const unirepContract = new ethers.Contract(
       UNIREP_ADDRESS,
@@ -172,6 +172,9 @@ class User {
     this.userStates[platform].latestTransitionedEpoch =
       this.userStates[platform].userState.sync.calcCurrentEpoch();
     this.updateHasSignedUp();
+
+    /* Store access_token to local storage */
+    await this.storeAccessToken(platform, access_token);
   }
 
   async stateTransition(platform) {
@@ -278,6 +281,13 @@ class User {
     this.userStates = {};
     this.hasSignedUp = false;
     window.localStorage.removeItem("id"); // for if anyone else wanna sign up and use
+  }
+
+  async storeAccessToken(platform, access_token) {
+    await this.waitForLoad(platform);
+
+    window.localStorage.setItem(`${platform}_access_token`, access_token);
+    this.userStates[platform].access_token = access_token;
   }
 }
 

--- a/packages/frontend/src/pages/Join.jsx
+++ b/packages/frontend/src/pages/Join.jsx
@@ -1,7 +1,14 @@
 import React, { useEffect, useState, useContext } from "react";
 import { observer } from "mobx-react-lite";
 import { Link, useNavigate, useSearchParams } from "react-router-dom";
-import { Button, Divider, Input, Loader, Message } from "semantic-ui-react";
+import {
+  Button,
+  Divider,
+  Loader,
+  Message,
+  TextArea,
+  Form,
+} from "semantic-ui-react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faTwitter, faGithub } from "@fortawesome/free-brands-svg-icons";
 import { SERVER } from "../config.js";
@@ -15,6 +22,7 @@ export default observer(() => {
 
   const [isLoading, setIsLoading] = useState(false);
   const [errorMsg, setErrorMsg] = useState("");
+  const [idInput, setIdInput] = useState("");
 
   const signup = async (platform, access_token) => {
     setErrorMsg("");
@@ -68,6 +76,19 @@ export default observer(() => {
     }
   };
 
+  const login = async () => {
+    try {
+      await user.login(idInput);
+      return navigate("/user");
+    } catch (e) {
+      setErrorMsg(e.toString());
+    }
+  };
+
+  const onIdInputChange = (event) => {
+    setIdInput(event.target.value);
+  };
+
   return (
     <>
       {isLoading ? (
@@ -101,11 +122,16 @@ export default observer(() => {
 
           <Divider horizontal>Already has account?</Divider>
 
-          <Input placeholder="Please enter your private key." size="large" />
-          <Button basic size="large">
+          <Form>
+            <TextArea
+              placeholder="Please enter your private key."
+              style={{ width: "300px" }}
+              onChange={onIdInputChange}
+            />
+          </Form>
+          <Button basic size="large" onClick={login}>
             Log in
           </Button>
-
           <Link to="/help">Any question?</Link>
         </div>
       )}

--- a/packages/frontend/src/pages/Join.jsx
+++ b/packages/frontend/src/pages/Join.jsx
@@ -41,19 +41,19 @@ export default observer(() => {
     const platform = params.get("platform");
     const access_token = params.get("access_token");
     const signupError = params.get("signupError");
+    const isSigningUp = params.get("isSigningUp");
     if (platform && access_token) {
-      signup(platform, access_token);
-      params.delete("platform");
-      params.delete("access_token");
-      params.delete("signupCode");
+      if (isSigningUp && parseInt(isSigningUp)) {
+        signup(platform, access_token);
+      } else {
+        user.storeAccessToken(platform, access_token);
+      }
     } else if (signupError) {
       setErrorMsg(
         `Sign up through ${platform.toUpperCase()} error: ${signupError}`
       );
-      params.delete("platform");
-      params.delete("signupError");
     }
-    setParams(params);
+    setParams("");
   }, []);
 
   const join = async (platform) => {
@@ -66,10 +66,12 @@ export default observer(() => {
     if (platform === "twitter") {
       const url = new URL("/api/oauth/twitter", SERVER);
       url.searchParams.set("redirectDestination", dest.toString());
+      url.searchParams.set("isSigningUp", true);
       window.location.replace(url.toString());
     } else if (platform === "github") {
       const url = new URL("/api/oauth/github", SERVER);
       url.searchParams.set("redirectDestination", dest.toString());
+      url.searchParams.set("isSigningUp", true);
       window.location.replace(url.toString());
     } else {
       console.log("wwaitttt whatttt???");

--- a/packages/frontend/src/pages/User.jsx
+++ b/packages/frontend/src/pages/User.jsx
@@ -41,19 +41,19 @@ export default observer(() => {
     const platform = params.get("platform");
     const access_token = params.get("access_token");
     const signupError = params.get("signupError");
+    const isSigningUp = params.get("isSigningUp");
     if (platform && access_token) {
-      signup(platform, access_token);
-      params.delete("platform");
-      params.delete("access_token");
-      params.delete("signupCode");
+      if (isSigningUp && parseInt(isSigningUp)) {
+        signup(platform, access_token);
+      } else {
+        user.storeAccessToken(platform, access_token);
+      }
     } else if (signupError) {
       let tmpError = { ...errorMsg };
       tmpError[platform] = signupError;
       setErrorMsg(tmpError);
-      params.delete("platform");
-      params.delete("signupError");
     }
-    setParams(params);
+    setParams("");
   }, []);
 
   const connect = async (platform) => {
@@ -68,14 +68,17 @@ export default observer(() => {
     // authorization through relay
     const currentUrl = new URL(window.location.href);
     const dest = new URL("/user", currentUrl.origin);
+    const isSigningUp = !user.userStates[platform].hasSignedUp;
 
     if (platform === "twitter") {
       const url = new URL("/api/oauth/twitter", SERVER);
       url.searchParams.set("redirectDestination", dest.toString());
+      url.searchParams.set("isSigningUp", isSigningUp);
       window.location.replace(url.toString());
     } else if (platform === "github") {
       const url = new URL("/api/oauth/github", SERVER);
       url.searchParams.set("redirectDestination", dest.toString());
+      url.searchParams.set("isSigningUp", isSigningUp);
       window.location.replace(url.toString());
     } else {
       let tmpError = { ...errorMsg };
@@ -154,6 +157,7 @@ export default observer(() => {
               title={"Twitter"}
               platform={"twitter"}
               hasSignedUp={user.userStates.twitter.hasSignedUp}
+              connected={user.userStates.twitter.access_token !== null}
               data={Number(
                 user.userStates.twitter.data[0] -
                   user.userStates.twitter.data[1]
@@ -173,6 +177,7 @@ export default observer(() => {
               title={"Github Stars"}
               platform={"github"}
               hasSignedUp={user.userStates.github.hasSignedUp}
+              connected={user.userStates.github.access_token !== null}
               data={Number(
                 user.userStates.github.data[2] - user.userStates.github.data[3]
               )}
@@ -191,6 +196,7 @@ export default observer(() => {
               title={"Github Followers"}
               platform={"github"}
               hasSignedUp={user.userStates.github.hasSignedUp}
+              connected={user.userStates.github.access_token !== null}
               data={Number(
                 user.userStates.github.data[0] - user.userStates.github.data[1]
               )}

--- a/packages/relay/src/singletons/schema.mjs
+++ b/packages/relay/src/singletons/schema.mjs
@@ -12,6 +12,7 @@ const _schema = [
       },
       ["type", "String"],
       ["redirectDestination", "String"],
+      ["isSigningUp", "Bool"],
       ["data", "String", { optional: true }],
     ],
   },


### PR DESCRIPTION
## Frontend ##
- update **InfoCard** styling, to display *unconnected* if the user doesn't have `access_token`
- make `storeAccessToken` an independent function in **UserContext**
- `access_token` is stored in the localStorage and memory
- send `isSigningUp` to relay, and to tell if the frontend needs to call `signup` by returning params named `isSigningUp` from the relay. If `isSigningUp` is false, then skip the `signup` call and just store the `access_token` by calling `storeAccessToken`
- remove *params* after parsing them right away
- re-styling the **Sign In** block

## Relay ##
- inside **OAuthRouter**, parse `isSigningUp` params from the *POST* request, and store it inside `OAuthState`
- modify the schema of `OAuthState` --> add a new column to store `isSigningUp` argument
- return `isSigningUp` in the **destinationURL** (which should be the url of frontend) 

close #29 